### PR TITLE
Add symlink to `Processing` for `ZDriftMetrics`

### DIFF
--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -361,7 +361,7 @@ class ZDriftMetrics(dj.Computed):
             return np.convolve(m, k, mode="full") / k.sum()
 
         nchannels = (scan.ScanInfo & key).fetch1("nchannels")
-        output_dir = (ProcessingParamSet & key).fetch1("processing_output_dir")
+        output_dir = (ProcessingTask & key).fetch1("processing_output_dir")
         drift_params = (ZDriftParamSet & key).fetch1("params")
         image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
         image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -326,7 +326,9 @@ class ZDriftParamSet(dj.Manual):
 
         if q_param:  # If the specified param-set already exists
             p_name = q_param.fetch1("zdrift_paramset_idx")
-            if p_name == zdrift_paramset_idx:  # If the existed set has the same name: job done
+            if (
+                p_name == zdrift_paramset_idx
+            ):  # If the existed set has the same name: job done
                 return
             else:  # If not same name: human error, trying to add the same paramset with different name
                 raise dj.DataJointError(
@@ -454,7 +456,7 @@ class ZDriftMetrics(dj.Computed):
         ]
 
         bad_frames_idx = np.where(drift >= drift_params["bad_frames_threshold"])[0]
-        
+
         self.insert1(
             dict(**key, bad_frames=bad_frames_idx, z_drift=drift),
         )
@@ -525,14 +527,11 @@ class Processing(dj.Computed):
             drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
             if drop_frames.size > 0:
                 np.save(pathlib.Path(output_dir) / "bad_frames.npy", drop_frames)
-                print("array saved")
-
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 files_to_link = [
                     find_full_path(get_imaging_root_data_dir(), raw_image_file)
                     for raw_image_file in raw_image_files
                 ]
-
                 image_files = []
                 for file in files_to_link:
                     if not (pathlib.Path(output_dir) / file.name).is_symlink():
@@ -540,7 +539,7 @@ class Processing(dj.Computed):
                         image_files.append((pathlib.Path(output_dir) / file.name))
                     else:
                         image_files.append((pathlib.Path(output_dir) / file.name))
-            
+
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [
@@ -572,7 +571,6 @@ class Processing(dj.Computed):
                     "data_path": [image_files[0].parent.as_posix()],
                     "tiff_list": [f.as_posix() for f in image_files],
                 }
-                print([image_files[0].parent.as_posix()])
                 suite2p.run_s2p(ops=suite2p_params, db=suite2p_paths)  # Run suite2p
 
                 _, imaging_dataset = get_loader_result(key, ProcessingTask)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -500,7 +500,7 @@ class Processing(dj.Computed):
             ProcessingTask.update1(
                 {**key, "processing_output_dir": output_dir.as_posix()}
             )
-        output_dir = find_full_path(get_imaging_root_data_dir(), output_dir).as_posix()
+        output_dir = find_full_path(get_imaging_root_data_dir(), output_dir)
         print(output_dir)
 
         if task_mode == "load":

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -525,7 +525,7 @@ class Processing(dj.Computed):
         elif task_mode == "trigger":
             drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
             if drop_frames.size > 0:
-                outbox_symlink_path = (output_dir / "curation").as_posix()
+                outbox_symlink_path = (pathlib.Path(output_dir) / "curation")
                 outbox_symlink_path.mkdir(parents=True, exist_ok=True)
                 if outbox_symlink_path.exists():
                     outbox_symlink_path.unlink()

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -361,7 +361,6 @@ class ZDriftMetrics(dj.Computed):
             return np.convolve(m, k, mode="full") / k.sum()
 
         nchannels = (scan.ScanInfo & key).fetch1("nchannels")
-        output_dir = (ProcessingTask & key).fetch1("processing_output_dir")
         drift_params = (ZDriftParamSet & key).fetch1("z_params")
         image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
         image_files = [
@@ -526,8 +525,11 @@ class Processing(dj.Computed):
             drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
             if drop_frames.size > 0:
                 outbox_symlink_path = (pathlib.Path(output_dir) / "curation")
+                print(outbox_symlink_path)
                 outbox_symlink_path.mkdir(parents=True, exist_ok=True)
+                print("folder created.")
                 np.save((outbox_symlink_path / "bad_frames.npy"), drop_frames)
+                print("array saved")
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 files_to_link = [
                     find_full_path(get_imaging_root_data_dir(), raw_image_file)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -525,7 +525,7 @@ class Processing(dj.Computed):
         elif task_mode == "trigger":
             drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
             if drop_frames.size > 0:
-                np.save(output_dir / "bad_frames.npy", drop_frames)
+                np.save(pathlib.Path(output_dir / "bad_frames.npy"), drop_frames)
                 print("array saved")
 
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -525,11 +525,7 @@ class Processing(dj.Computed):
         elif task_mode == "trigger":
             drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
             if drop_frames.size > 0:
-                outbox_symlink_path = (pathlib.Path(output_dir) / "curation")
-                print(outbox_symlink_path)
-                outbox_symlink_path.mkdir(parents=True, exist_ok=True)
-                print("folder created.")
-                np.save(pathlib.Path(*outbox_symlink_path.parts[:2]) / "bad_frames.npy", drop_frames)
+                np.save(output_dir / "bad_frames.npy", drop_frames)
                 print("array saved")
 
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
@@ -538,17 +534,14 @@ class Processing(dj.Computed):
                     for raw_image_file in raw_image_files
                 ]
 
-                image_files=[]
+                image_files = []
                 for file in files_to_link:
-                    if not (outbox_symlink_path / file.name).is_symlink():
-                        (outbox_symlink_path / file.name).symlink_to(file)
-                        image_files.append((outbox_symlink_path / file.name))
+                    if not (output_dir / file.name).is_symlink():
+                        (output_dir / file.name).symlink_to(file)
+                        image_files.append((output_dir / file.name))
                     else:
-                        image_files.append((outbox_symlink_path / file.name))
-                        continue
+                        image_files.append((output_dir / file.name))
             
-                if not (pathlib.Path(*outbox_symlink_path.parts[:2]) / "bad_frames.npy").is_symlink():
-                    (pathlib.Path(*outbox_symlink_path.parts[:2]) / "bad_frames.npy").symlink_to(outbox_symlink_path / "bad_frames.npy")
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -531,19 +531,24 @@ class Processing(dj.Computed):
                 print("folder created.")
                 np.save((outbox_symlink_path / "bad_frames.npy"), drop_frames)
                 print("array saved")
+
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 files_to_link = [
                     find_full_path(get_imaging_root_data_dir(), raw_image_file)
                     for raw_image_file in raw_image_files
                 ]
-                image_files=[]
-                for file in files_to_link:
-                    if not (outbox_symlink_path / file.name).is_symlink():
-                        (outbox_symlink_path / file.name).symlink_to(file)
-                        image_files.append((outbox_symlink_path / file.name))
-                    else:
-                        image_files.append((outbox_symlink_path / file.name))
-                        continue
+                if not (files_to_link[0].parent / "bad_frames.npy").is_symlink():
+                    ((files_to_link[0].parent / "bad_frames.npy")).symlink_to((outbox_symlink_path / "bad_frames.npy"))
+                
+                image_files = files_to_link
+                # image_files=[]
+                # for file in files_to_link:
+                #     if not (outbox_symlink_path / file.name).is_symlink():
+                #         (outbox_symlink_path / file.name).symlink_to(file)
+                #         image_files.append((outbox_symlink_path / file.name))
+                #     else:
+                #         image_files.append((outbox_symlink_path / file.name))
+                #         continue
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -572,7 +572,7 @@ class Processing(dj.Computed):
                     "data_path": [image_files[0].parent.as_posix()],
                     "tiff_list": [f.as_posix() for f in image_files],
                 }
-
+                print([image_files[0].parent.as_posix()])
                 suite2p.run_s2p(ops=suite2p_params, db=suite2p_paths)  # Run suite2p
 
                 _, imaging_dataset = get_loader_result(key, ProcessingTask)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -528,13 +528,18 @@ class Processing(dj.Computed):
                 outbox_symlink_path = (pathlib.Path(output_dir) / "curation")
                 outbox_symlink_path.mkdir(parents=True, exist_ok=True)
                 np.save((outbox_symlink_path / "bad_frames.npy"), drop_frames)
-                image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
+                raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 files_to_link = [
-                    find_full_path(get_imaging_root_data_dir(), image_file)
-                    for image_file in image_files
+                    find_full_path(get_imaging_root_data_dir(), raw_image_file)
+                    for raw_image_file in raw_image_files
                 ]
+                image_files=[]
                 for file in files_to_link:
-                    (outbox_symlink_path / file.name).symlink_to(file)
+                    if not (outbox_symlink_path / file.name).is_symlink():
+                        (outbox_symlink_path / file.name).symlink_to(file)
+                        image_files.append((outbox_symlink_path / file.name))
+                    else:
+                        continue
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -524,9 +524,13 @@ class Processing(dj.Computed):
             else:
                 raise NotImplementedError("Unknown method: {}".format(method))
         elif task_mode == "trigger":
-            drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
-            if drop_frames.size > 0:
-                np.save(pathlib.Path(output_dir) / "bad_frames.npy", drop_frames)
+            drop_frames = (ZDriftMetrics & key).fetch("bad_frames")
+            if len(drop_frames) > 1:
+                raise dj.DataJointError(
+                    "Processing more than 1 set of `bad_frames` per scan is not currently supported."
+                )
+            if drop_frames[0].size > 0:
+                np.save(pathlib.Path(output_dir) / "bad_frames.npy", drop_frames[0])
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 files_to_link = [
                     find_full_path(get_imaging_root_data_dir(), raw_image_file)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -527,8 +527,6 @@ class Processing(dj.Computed):
             if drop_frames.size > 0:
                 outbox_symlink_path = (pathlib.Path(output_dir) / "curation")
                 outbox_symlink_path.mkdir(parents=True, exist_ok=True)
-                if outbox_symlink_path.exists():
-                    outbox_symlink_path.unlink()
                 np.save((outbox_symlink_path / "bad_frames.npy"), drop_frames)
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 outbox_symlink_path.symlink_to([

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -500,8 +500,7 @@ class Processing(dj.Computed):
             ProcessingTask.update1(
                 {**key, "processing_output_dir": output_dir.as_posix()}
             )
-        output_dir = find_full_path(get_imaging_root_data_dir(), output_dir)
-        print(output_dir)
+        output_dir = find_full_path(get_imaging_root_data_dir(), output_dir).as_posix()
 
         if task_mode == "load":
             method, imaging_dataset = get_loader_result(key, ProcessingTask)
@@ -536,11 +535,11 @@ class Processing(dj.Computed):
 
                 image_files = []
                 for file in files_to_link:
-                    if not (output_dir / file.name).is_symlink():
-                        (output_dir / file.name).symlink_to(file)
-                        image_files.append((output_dir / file.name))
+                    if not (pathlib.Path(output_dir) / file.name).is_symlink():
+                        (pathlib.Path(output_dir) / file.name).symlink_to(file)
+                        image_files.append((pathlib.Path(output_dir) / file.name))
                     else:
-                        image_files.append((output_dir / file.name))
+                        image_files.append((pathlib.Path(output_dir) / file.name))
             
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -524,13 +524,14 @@ class Processing(dj.Computed):
             else:
                 raise NotImplementedError("Unknown method: {}".format(method))
         elif task_mode == "trigger":
-            drop_frames = (ZDriftMetrics & key).fetch("bad_frames")
-            if len(drop_frames) > 1:
+            try:
+                drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
+            except dj.DataJointError:
                 raise dj.DataJointError(
                     "Processing more than 1 set of `bad_frames` per scan is not currently supported."
                 )
-            if drop_frames[0].size > 0:
-                np.save(pathlib.Path(output_dir) / "bad_frames.npy", drop_frames[0])
+            if drop_frames.size > 0:
+                np.save(pathlib.Path(output_dir) / "bad_frames.npy", drop_frames)
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 files_to_link = [
                     find_full_path(get_imaging_root_data_dir(), raw_image_file)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -534,10 +534,7 @@ class Processing(dj.Computed):
                     for image_file in image_files
                 ]
                 for file in files_to_link:
-                    if not file.is_symlink():
-                        outbox_symlink_path.symlink_to(file)
-                    else:
-                        continue
+                    (outbox_symlink_path / file.name).symlink_to(file)
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -539,6 +539,7 @@ class Processing(dj.Computed):
                         (outbox_symlink_path / file.name).symlink_to(file)
                         image_files.append((outbox_symlink_path / file.name))
                     else:
+                        image_files.append((outbox_symlink_path / file.name))
                         continue
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -529,10 +529,12 @@ class Processing(dj.Computed):
                 outbox_symlink_path.mkdir(parents=True, exist_ok=True)
                 np.save((outbox_symlink_path / "bad_frames.npy"), drop_frames)
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
-                outbox_symlink_path.symlink_to([
+                files_to_link = [
                     find_full_path(get_imaging_root_data_dir(), image_file)
                     for image_file in image_files
-                ])
+                ]
+                for file in files_to_link:
+                    outbox_symlink_path.symlink_to(file)
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -537,18 +537,15 @@ class Processing(dj.Computed):
                     find_full_path(get_imaging_root_data_dir(), raw_image_file)
                     for raw_image_file in raw_image_files
                 ]
-                if not (files_to_link[0].parent / "bad_frames.npy").is_symlink():
-                    ((files_to_link[0].parent / "bad_frames.npy")).symlink_to((outbox_symlink_path / "bad_frames.npy"))
-                
-                image_files = files_to_link
-                # image_files=[]
-                # for file in files_to_link:
-                #     if not (outbox_symlink_path / file.name).is_symlink():
-                #         (outbox_symlink_path / file.name).symlink_to(file)
-                #         image_files.append((outbox_symlink_path / file.name))
-                #     else:
-                #         image_files.append((outbox_symlink_path / file.name))
-                #         continue
+
+                image_files=[]
+                for file in files_to_link:
+                    if not (outbox_symlink_path / file.name).is_symlink():
+                        (outbox_symlink_path / file.name).symlink_to(file)
+                        image_files.append((outbox_symlink_path / file.name))
+                    else:
+                        image_files.append((outbox_symlink_path / file.name))
+                        continue
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -529,7 +529,7 @@ class Processing(dj.Computed):
                 print(outbox_symlink_path)
                 outbox_symlink_path.mkdir(parents=True, exist_ok=True)
                 print("folder created.")
-                np.save((outbox_symlink_path / "bad_frames.npy"), drop_frames)
+                np.save(pathlib.Path(*outbox_symlink_path.parts[:2]) / "bad_frames.npy", drop_frames)
                 print("array saved")
 
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
@@ -546,6 +546,9 @@ class Processing(dj.Computed):
                     else:
                         image_files.append((outbox_symlink_path / file.name))
                         continue
+            
+                if not (pathlib.Path(*outbox_symlink_path.parts[:2]) / "bad_frames.npy").is_symlink():
+                    (pathlib.Path(*outbox_symlink_path.parts[:2]) / "bad_frames.npy").symlink_to(outbox_symlink_path / "bad_frames.npy")
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -294,8 +294,7 @@ class ZDriftParamSet(dj.Manual):
     zdrift_paramset_idx: int
     ---
     z_paramset_desc: varchar(1280)  # Parameter-set description
-    z_param_set_hash: uuid  # A universally unique identifier for the parameter set
-    unique index (param_set_hash)
+    z_param_set_hash: uuid  # # A universally unique identifier for the parameter set.
     z_params: longblob  # Parameter Set, a dictionary of all z-drift parameters.
     """
 

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -501,6 +501,7 @@ class Processing(dj.Computed):
                 {**key, "processing_output_dir": output_dir.as_posix()}
             )
         output_dir = find_full_path(get_imaging_root_data_dir(), output_dir).as_posix()
+        print(output_dir)
 
         if task_mode == "load":
             method, imaging_dataset = get_loader_result(key, ProcessingTask)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -534,7 +534,10 @@ class Processing(dj.Computed):
                     for image_file in image_files
                 ]
                 for file in files_to_link:
-                    outbox_symlink_path.symlink_to(file)
+                    if not file.is_symlink():
+                        outbox_symlink_path.symlink_to(file)
+                    else:
+                        continue
             else:
                 image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
                 image_files = [

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -362,7 +362,7 @@ class ZDriftMetrics(dj.Computed):
 
         nchannels = (scan.ScanInfo & key).fetch1("nchannels")
         output_dir = (ProcessingTask & key).fetch1("processing_output_dir")
-        drift_params = (ZDriftParamSet & key).fetch1("params")
+        drift_params = (ZDriftParamSet & key).fetch1("z_params")
         image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")
         image_files = [
             find_full_path(get_imaging_root_data_dir()[0], image_file)

--- a/element_calcium_imaging/imaging_no_curation.py
+++ b/element_calcium_imaging/imaging_no_curation.py
@@ -525,7 +525,7 @@ class Processing(dj.Computed):
         elif task_mode == "trigger":
             drop_frames = (ZDriftMetrics & key).fetch1("bad_frames")
             if drop_frames.size > 0:
-                np.save(pathlib.Path(output_dir / "bad_frames.npy"), drop_frames)
+                np.save(pathlib.Path(output_dir) / "bad_frames.npy", drop_frames)
                 print("array saved")
 
                 raw_image_files = (scan.ScanInfo.ScanFile & key).fetch("file_path")


### PR DESCRIPTION
This implementation is one suggestion but it might make more sense to create a table downstream from `ZDriftMetrics` called `DropFrames` with a foreign key reference to `ZDriftMetrics`. `DropFrames` would also have an additional boolean attribute indicating whether it was necessary to drop frames or not based on the drift values generated for each frame in `ZDriftMetrics`. If `False`, the `Processing` table will look for the raw data in the inbox, if `True` the `Processing` table will look for a symlink in the outbox. 